### PR TITLE
add -mno-fma to  for Libint 2.0.3 with foss/2018b

### DIFF
--- a/easybuild/easyconfigs/l/Libint/Libint-2.0.3-foss-2018b.eb
+++ b/easybuild/easyconfigs/l/Libint/Libint-2.0.3-foss-2018b.eb
@@ -12,4 +12,7 @@ source_urls = ['http://downloads.sourceforge.net/project/libint/libint-for-mpqc'
 sources = ['libint-%(version)s-stable.tgz']
 checksums = ['5d4944ed6e60b08d05b4e396b10dc7deee7968895984f4892fd17159780f5b02']
 
+# need to prevent GCC from emiting FMA instructions due to bugs in include/vector_x86.h for Libint 2.0.x
+preconfigopts = 'export CXXFLAGS="$CXXFLAGS -mno-fma" && '
+
 moduleclass = 'chem'


### PR DESCRIPTION
@tovrstra fix for build issue that surfaced in https://github.com/easybuilders/easybuild-easyconfigs/pull/7449