### PR TITLE
disable use of -march=native for PCMSolver built with foss/2018b, because of failing test if it's enabled

### DIFF
--- a/easybuild/easyconfigs/p/PCMSolver/PCMSolver-1.2.3-foss-2018b-Python-3.6.6.eb
+++ b/easybuild/easyconfigs/p/PCMSolver/PCMSolver-1.2.3-foss-2018b-Python-3.6.6.eb
@@ -8,6 +8,9 @@ homepage = 'https://pcmsolver.readthedocs.org'
 description = """An API for the Polarizable Continuum Model."""
 
 toolchain = {'name': 'foss', 'version': '2018b'}
+# we have to disable use of -march=native to ensure a correct build on recent Intel systems
+# see also https://github.com/PCMSolver/pcmsolver/issues/159
+toolchainopts = {'optarch': False}
 
 source_urls = ['https://github.com/PCMSolver/pcmsolver/archive/']
 sources = ['v%(version)s.tar.gz']


### PR DESCRIPTION
@tovrstra One more required update for https://github.com/easybuilders/easybuild-easyconfigs/pull/7761 (see also https://github.com/PCMSolver/pcmsolver/issues/159)